### PR TITLE
Add Visual Indication for Incorrect Words #11

### DIFF
--- a/app/src/main/java/com/example/android/unscramble/MainActivity.kt
+++ b/app/src/main/java/com/example/android/unscramble/MainActivity.kt
@@ -2,10 +2,14 @@ package com.example.android.unscramble
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.main_activity)
+//        Text txt = findViewById(R.id.textField)
     }
 }

--- a/app/src/main/java/com/example/android/unscramble/ui/game/GameFragment.kt
+++ b/app/src/main/java/com/example/android/unscramble/ui/game/GameFragment.kt
@@ -1,5 +1,6 @@
 package com.example.android.unscramble.ui.game
 
+import android.graphics.Color
 import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
@@ -11,6 +12,7 @@ import androidx.fragment.app.viewModels
 import com.example.android.unscramble.R
 import com.example.android.unscramble.databinding.GameFragmentBinding
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputLayout
 
 /**
  * Fragment where the game is played, contains the game logic.
@@ -88,10 +90,12 @@ class GameFragment : Fragment() {
     }
 
     private fun setErrorTextField(error: Boolean) {
+//        TextInputLayout txt = findViewById(R.id.textField)
         if (error) {
-//
+            binding.textField.error = "wrong";
+//          .setTextColor(Color.RED);
         } else {
-//
+            binding.textField.error = "";
         }
     }
 


### PR DESCRIPTION
fixes: #11 
Add Visual Indication for Incorrect Words #11

used `binding.textField.error = "wrong";` to set the textfield color to red and `binding.textField.error = "";` to set it back to normal

screenshot:
![chrome-capture-2024-3-17 (5)](https://github.com/iiitl/Jumble_Words/assets/65962770/62696b82-3c03-4c47-9828-b6bf9ae336cb)
